### PR TITLE
fix converter header files including path

### DIFF
--- a/converter/convert_model.py
+++ b/converter/convert_model.py
@@ -198,7 +198,7 @@ def convert_model(path: str):
         name="wkv_cuda_export",
         sources=[os.path.join(current_path, "cpp_save_tensor.cpp")],
         # add ../include to include path
-        extra_include_paths=[os.path.join(current_path, "../include/rwkv/rwkv")],
+        extra_include_paths=[os.path.join(current_path, "../include/")],
         )
 
     w = torch.load(path, map_location="cpu")


### PR DESCRIPTION
Converter includes a wrong path and causes the following compile error.
```
rwkv-cpp-accelerated/include/rwkv/rwkv/rwkv.h:8:10: fatal error: rwkv/enums/enum.h: No such file or directory
    8 | #include "rwkv/enums/enum.h"
      |          ^~~~~~~~~~~~~~~~~~~
compilation terminated.
ninja: build stopped: subcommand failed.
```